### PR TITLE
Fixes

### DIFF
--- a/packages/react-pdf-highlighter/src/components/PdfHighlighter.js
+++ b/packages/react-pdf-highlighter/src/components/PdfHighlighter.js
@@ -263,10 +263,6 @@ class PdfHighlighter<T_HT: T_Highlight> extends PureComponent<
 
   screenshot(position: T_LTWH, pageNumber: number) {
     const canvas = this.viewer.getPageView(pageNumber - 1).canvas;
-    position.height = position.height / this.props.scale;
-    position.width = position.width / this.props.scale;
-    position.left = position.left / this.props.scale;
-    position.top = position.top / this.props.scale;
     return getAreaAsPng(canvas, position);
   }
 
@@ -717,29 +713,7 @@ class PdfHighlighter<T_HT: T_Highlight> extends PureComponent<
                 const scaledPosition = this.viewportPositionToScaled(
                   viewportPosition
                 );
-
-                const copyScaledPosition = JSON.parse(
-                  JSON.stringify(scaledPosition)
-                );
-                const ghostHighlight = this.getGhostHighlight(
-                  copyScaledPosition,
-                  "",
-                  this.props.scale,
-                  this.props.rotate
-                ).position;
-
-                let screenShotRect = {
-                  left: ghostHighlight.boundingRect.x1,
-                  top: ghostHighlight.boundingRect.y1,
-                  width:
-                    ghostHighlight.boundingRect.x2 -
-                    ghostHighlight.boundingRect.x1,
-                  height:
-                    ghostHighlight.boundingRect.y2 -
-                    ghostHighlight.boundingRect.y1
-                };
-
-                const image = this.screenshot(screenShotRect, page.number);
+                const image = this.screenshot(viewportPosition.boundingRect, page.number);
 
                 this.renderTipAtPosition(
                   viewportPosition,
@@ -772,71 +746,11 @@ class PdfHighlighter<T_HT: T_Highlight> extends PureComponent<
     );
   }
 
-  getGhostHighlight(scaledPosition, image, scale, rotate) {
-    let boundingRect = scaledPosition.boundingRect;
-
-    scaledPosition.boundingRect = this.extracted(rotate, boundingRect);
-
+  getGhostHighlight(scaledPosition, image) {
     return {
       position: scaledPosition,
       content: { image }
     };
-  }
-
-  extracted(rotate, boundingRect) {
-    if (rotate === 0) {
-      //
-    }
-
-    if (rotate === 90) {
-      let x1 = boundingRect.x1;
-      let y1 = boundingRect.y1;
-      let x2 = boundingRect.x2;
-      let y2 = boundingRect.y2;
-      let width = boundingRect.width;
-      let height = boundingRect.height;
-
-      boundingRect.x1 = y1;
-      boundingRect.y1 = Math.abs(x2 - width);
-      boundingRect.x2 = y2;
-      boundingRect.y2 = Math.abs(x1 - width);
-      boundingRect.width = height;
-      boundingRect.height = width;
-    }
-
-    if (rotate === -90) {
-      let x1 = boundingRect.x1;
-      let y1 = boundingRect.y1;
-      let x2 = boundingRect.x2;
-      let y2 = boundingRect.y2;
-      let width = boundingRect.width;
-      let height = boundingRect.height;
-
-      boundingRect.x1 = Math.abs(y2 - height);
-      boundingRect.y2 = width - Math.abs(x2 - width);
-      boundingRect.x2 = Math.abs(y1 - height);
-      boundingRect.y1 = width - Math.abs(x1 - width);
-      boundingRect.width = height;
-      boundingRect.height = width;
-    }
-
-    if (rotate === -180 || rotate === 180) {
-      let x1 = boundingRect.x1;
-      let y1 = boundingRect.y1;
-      let x2 = boundingRect.x2;
-      let y2 = boundingRect.y2;
-      let width = boundingRect.width;
-      let height = boundingRect.height;
-
-      boundingRect.x1 = Math.abs(x2 - width);
-      boundingRect.y1 = Math.abs(y2 - height);
-      boundingRect.x2 = Math.abs(x1 - width);
-      boundingRect.y2 = Math.abs(y1 - height);
-      boundingRect.width = width;
-      boundingRect.height = height;
-    }
-
-    return boundingRect;
   }
 }
 

--- a/packages/react-pdf-highlighter/src/components/TipContainer.js
+++ b/packages/react-pdf-highlighter/src/components/TipContainer.js
@@ -59,11 +59,7 @@ class TipContainer extends Component<Props, State> {
 
     const top = shouldMove ? style.bottom + 5 : style.top - height - 5;
 
-    const left = clamp(
-      style.left - width / 2,
-      0,
-      pageBoundingRect.width - width
-    );
+    const left = style.left - width / 2;
 
     const childrenWithProps = React.Children.map(children, child =>
       React.cloneElement(child, {

--- a/packages/react-pdf-highlighter/src/lib/coordinates.js
+++ b/packages/react-pdf-highlighter/src/lib/coordinates.js
@@ -11,21 +11,35 @@ import type {T_LTWH, T_Scaled, T_VIEWPORT} from "../types";
 type WIDTH_HEIGHT = { width: number, height: number };
 
 export const viewportToScaled = (
-    rect: T_LTWH,
-    {width, height}: WIDTH_HEIGHT,
-    scale: string,
-    rotation: string
+    {left, top, width: w, height: h}: T_LTWH,
+    {width: vw, height: vh}: WIDTH_HEIGHT,
+    scale: number,
+    rotation: number
 ): T_Scaled => {
-    return {
-        x1: rect.left,
-        y1: rect.top,
-
-        x2: rect.left + rect.width,
-        y2: rect.top + rect.height,
-
-        width,
-        height
-    };
+    let x1 = left / scale;
+    let y1 = top / scale;
+    switch (rotation) {
+        case -180: case 180:
+            x1 = (vw - left - w) / scale;
+            y1 = (vh - top - h) / scale;
+            break;
+        case -90:
+            y1 = x1;
+            x1 = (vh - top - h) / scale;
+            break;
+        case 90:
+            x1 = y1;
+            y1 = (vw - left - w) / scale;
+            break;
+        default:
+            break;
+    }
+    const horizontal = Math.abs(rotation) === 90;
+    const height = (horizontal ? w : h) / scale;
+    const width = (horizontal ? h : w) / scale;
+    const x2 = x1 + width;
+    const y2 = y1 + height;
+    return {x1, x2, y1, y2, width, height};
 };
 
 const pdfToViewport = (pdf, viewport, currentScaleValue: string,


### PR DESCRIPTION
> 1. При зуме и(или) любом повороте выделение области с помощью option(ctrl) + выделение мышью - делает неправильный скриншот в сайдбаре
> 2. При одновременном зуме с поворотом уезжает область выделения при добавлении камента
> 5. значек комментария, при выделении с поворотом позиционируется неправильно